### PR TITLE
Update Azure VM Python & change entrypoint

### DIFF
--- a/azure/install.sh
+++ b/azure/install.sh
@@ -30,7 +30,7 @@ pip install -r requirements.txt
 # Copy judge runner to final program location
 cp -r ./ /usr/local/bin/judge_runner/
 
-ENTRYPOINT=entrypoint.py
+ENTRYPOINT=runner.py
 chmod +x /usr/local/bin/judge_runner/$ENTRYPOINT
 
 

--- a/azure/install.sh
+++ b/azure/install.sh
@@ -23,8 +23,14 @@ apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin do
 
 # Install Python and dependencies
 echo "-- Installing Python and dependencies"
-apt-get install -y python3 python3-pip
-pip install -r requirements.txt
+apt-get install -y software-properties-common wget
+add-apt-repository -y ppa:deadsnakes/ppa
+apt-get update
+apt-get install -y python3.12 python3.12-venv
+wget https://bootstrap.pypa.io/get-pip.py -O get-pip.py
+python3.12 get-pip.py
+
+python3.12 -m pip install -r requirements.txt
 
 
 # Copy judge runner to final program location

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-import sys
-import time
-
-if __name__ == "__main__":
-    # TODO: replace with production code, this is a sample for testing purposes
-    print("Hello there")
-    time.sleep(10)
-    sys.exit(123)

--- a/runner.py
+++ b/runner.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 The main class of the runner server. It handles the connection to the judge server.
 """

--- a/runner.py
+++ b/runner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.12
 """
 The main class of the runner server. It handles the connection to the judge server.
 """


### PR DESCRIPTION
Sets the entrypoint to the updated `runner.py` file. Also updates the Python version used by the Azure VMs to Python 3.12, as the previous 3.8 was not enough (at least 3.10 was required).