### PR TITLE
Azure VM deployment: add install command delay

### DIFF
--- a/.github/workflows/azureapp.yml
+++ b/.github/workflows/azureapp.yml
@@ -47,5 +47,5 @@ jobs:
             --version-name $TAG_NAME \
             --location ${{ vars.AZURE_LOCATION }} \
             --package-file-link "https://${{ vars.AZURE_APP_STORAGE }}.blob.core.windows.net/${{ vars.AZURE_APP_STORAGE_CONTAINER }}/app-$TAG_NAME.zip" \
-            --install-command "apt-get install -y unzip && unzip -d judge_runner -o app-$TAG_NAME.zip && cd judge_runner && chmod +x azure/install.sh && ./azure/install.sh" \
+            --install-command "sleep 20 && apt-get install -y unzip && unzip -d judge_runner -o app-$TAG_NAME.zip && cd judge_runner && chmod +x azure/install.sh && ./azure/install.sh" \
             --remove-command "chmod +x judge_runner/azure/uninstall.sh && ./judge_runner/azure/uninstall.sh"


### PR DESCRIPTION
Adds a 20 second delay to the install command, as from tests it seems to prevent the `apt install` command from failing.

It's not a pretty solution, but I don't know how else to fix it.


install success rates (successful / total):
- main application (test 1): 2/10
- main application (test 2): 4/10
- unzip only: 4/10
- sleep, then unzip: 10/10
- sleep, then main application: 10/10