### PR TITLE
Improve timeout

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -34,6 +34,8 @@ pip install -r validator/requirements.txt
 echo "Starting the main code"
 
 for file in /instances/*; do
+    echo "Starting benchmark instance $file"
+
     # copy instance into runenv
     rm -rf /app/runenv/instances/*
     cp $file /app/runenv/instances/instance


### PR DESCRIPTION
- Exclude build time (e.g. installing Python dependencies) from the timeout
- Make timeout per instance, rather than over all instances